### PR TITLE
fix logging

### DIFF
--- a/sam/__init__.py
+++ b/sam/__init__.py
@@ -1,0 +1,3 @@
+import logging
+logging.getLogger('matplotlib').setLevel(logging.WARNING)
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/sam/catalog_primitive/arc.py
+++ b/sam/catalog_primitive/arc.py
@@ -8,8 +8,7 @@ import numpy as np
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Arc(Primitive):

--- a/sam/catalog_primitive/line.py
+++ b/sam/catalog_primitive/line.py
@@ -3,8 +3,7 @@ from sam.primitive import Primitive, PrimitiveType
 from .point import Point
 
 import logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 class Line(Primitive):
     """Line Primitive."""

--- a/sam/primitive.py
+++ b/sam/primitive.py
@@ -5,8 +5,7 @@ from typing import Dict
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class PrimitiveType(enum.IntEnum):

--- a/sam/sketch.py
+++ b/sam/sketch.py
@@ -6,8 +6,7 @@ from sam.primitive import Primitive
 from sam.constraint import Constraint
 
 import logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 class Sketch:
     def __init__(self):

--- a/tests/unit/constraints/test_global.py
+++ b/tests/unit/constraints/test_global.py
@@ -5,8 +5,7 @@ from sam.catalog_constraint import *
 import unittest
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 class TestConstraintGlobal(unittest.TestCase):
 

--- a/tests/unit/primitives/test_arc.py
+++ b/tests/unit/primitives/test_arc.py
@@ -3,8 +3,7 @@ import unittest
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TestArc(unittest.TestCase):

--- a/tests/unit/primitives/test_circle.py
+++ b/tests/unit/primitives/test_circle.py
@@ -3,8 +3,7 @@ import unittest
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TestCircle(unittest.TestCase):

--- a/tests/unit/primitives/test_line.py
+++ b/tests/unit/primitives/test_line.py
@@ -3,8 +3,7 @@ import unittest
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TestPrimitive(unittest.TestCase):

--- a/tests/unit/primitives/test_point.py
+++ b/tests/unit/primitives/test_point.py
@@ -3,8 +3,7 @@ import unittest
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TestCircle(unittest.TestCase):

--- a/tests/unit/test_sketch.py
+++ b/tests/unit/test_sketch.py
@@ -7,8 +7,7 @@ import pickle
 from pathlib import Path
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TestSketch(unittest.TestCase):


### PR DESCRIPTION
This pr reimplements logging following recommendations from the logging module
That is: 
- no basicconfig in modules
- loggers named after the __name__ variable to track module name